### PR TITLE
Add remote-config flag for homepage developer/mentor focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ pnpm-debug.log*
 .DS_Store
 
 blog/
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ Replace npm with your package manager of choice. `npm`, `pnpm`, `yarn`, `bun`, e
 | `npm run lint`            | Run ESLint                                       |
 | `npm run lint:fix`        | Auto-fix ESLint issues                           |
 
+## 🚩 Homepage focus flag
+
+The homepage (`src/pages/index.astro`) has two content variants — `developer` and `mentor` —
+covering the hero and About section. Which one is shown is controlled by a remote flag stored in
+[Netlify Blobs](https://docs.netlify.com/blobs/overview/) (store `site-config`, key
+`homepage-focus`), read at runtime by the `netlify/functions/focus-flag.mts` function and applied
+client-side. This means the flag can be flipped **without a redeploy** — the site is static, so
+both content variants are already in the built HTML; the client-side script just toggles which one
+is visible based on the function's response.
+
+If the flag is unset or holds any value other than `developer`/`mentor`, it defaults to
+`developer`.
+
+To change it, you need the [Netlify CLI](https://docs.netlify.com/cli/get-started/) installed and
+authenticated, and the local repo linked to the live site (`netlify link`, one-time setup):
+
+```bash
+netlify blobs:set site-config homepage-focus mentor    # switch to the mentor variant
+netlify blobs:set site-config homepage-focus developer # switch back to the developer variant
+```
+
+Only whoever has Netlify CLI access to the site (currently just me) can do this — it's not exposed
+anywhere in the UI or the public repo.
+
 ## 🗺️ Roadmap
 
 A few features I plan to implement

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+  functions = "netlify/functions"
+
+[dev]
+  command = "npm run dev"
+  targetPort = 4321
+  framework = "astro"

--- a/netlify/functions/focus-flag.mts
+++ b/netlify/functions/focus-flag.mts
@@ -1,0 +1,19 @@
+import { getStore } from "@netlify/blobs"
+
+const STORE_NAME = "site-config"
+const KEY = "homepage-focus"
+const DEFAULT_FOCUS = "developer"
+const VALID_VALUES = new Set(["developer", "mentor"])
+
+export default async () => {
+  const store = getStore(STORE_NAME)
+  const stored = await store.get(KEY)
+  const focus = VALID_VALUES.has(stored as string) ? stored : DEFAULT_FOCUS
+
+  return new Response(JSON.stringify({ focus }), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=60",
+    },
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@astrojs/sitemap": "^3.1.1",
         "@astrojs/solid-js": "^4.0.1",
         "@astrojs/tailwind": "^5.1.0",
+        "@netlify/blobs": "^8.1.0",
         "@tailwindcss/typography": "^0.5.10",
         "astro": "^4.4.13",
         "clsx": "^2.1.0",
@@ -734,6 +735,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@netlify/blobs": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-8.2.0.tgz",
+      "integrity": "sha512-9djLZHBKsoKk8XCgwWSEPK9QnT8qqxEQGuYh48gFIcNLvpBKkLnHbDZuyUxmNemCfDz7h0HnMXgSPnnUVgARhg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4802,22 +4812,6 @@
       },
       "engines": {
         "node": ">=18.12"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.5.6",
+    "@netlify/blobs": "^8.1.0",
     "@astrojs/mdx": "^2.1.1",
     "@astrojs/rss": "^4.0.5",
     "@astrojs/sitemap": "^3.1.1",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,7 +61,28 @@ const stack = [
   </div>
 
   <script is:inline src="/js/bg.js"></script>
-  
+
+  <script>
+    const VALID_FOCUS_VALUES = ["developer", "mentor"]
+
+    async function applyHomepageFocus() {
+      try {
+        const response = await fetch("/.netlify/functions/focus-flag")
+        if (!response.ok) return
+
+        const { focus } = await response.json()
+        if (focus !== "mentor" || !VALID_FOCUS_VALUES.includes(focus)) return
+
+        document.querySelectorAll<HTMLElement>('[data-focus="developer"]').forEach(el => el.hidden = true)
+        document.querySelectorAll<HTMLElement>('[data-focus="mentor"]').forEach(el => el.hidden = false)
+      } catch {
+        // Network/parse errors: keep the default "developer" content already rendered.
+      }
+    }
+
+    applyHomepageFocus()
+  </script>
+
   <style>
     html {
       scroll-behavior: smooth;
@@ -83,7 +104,26 @@ const stack = [
     </div>
     <div class="animate absolute h-full w-full flex items-center justify-center">
       <div class='relative w-full h-full flex items-center justify-center'>
-        <div class='p-5 text-center'>
+        <div id="hero-developer" data-focus="developer" class='p-5 text-center'>
+          <p class='animated text-lg md:text-xl lg:text-2xl font-semibold opacity-75'>
+            Hello, I am ...
+          </p>
+          <p class='animated text-2xl md:text-3xl lg:text-4xl font-bold text-black dark:text-white'>
+            Rodrigo 🙋🏻‍♂️
+          </p>
+          <p class='animated text-sm md:text-base lg:text-lg opacity-100'>
+            Currently developing apps for human kind 🚀
+          </p>
+          <div class='animated flex flex-wrap gap-4 justify-center mt-5'>
+            <a href='/projects' class='py-2 px-4 rounded truncate text-xs md:text-sm lg:text-base bg-black dark:bg-white text-white dark:text-black hover:opacity-75 blend'>
+              Check out my projects
+            </a>
+            <a href='/work' class='py-2 px-4 truncate rounded text-xs md:text-sm lg:text-base border border-black/25 dark:border-white/25 hover:bg-black/5 hover:dark:bg-white/15 blend'>
+              View my work
+            </a>
+          </div>
+        </div>
+        <div id="hero-mentor" data-focus="mentor" hidden class='p-5 text-center'>
           <p class='animated text-lg md:text-xl lg:text-2xl font-semibold opacity-75'>
             Hello, I am Rodrigo 🙋🏻‍♂️
           </p>
@@ -93,7 +133,7 @@ const stack = [
           <p class='animated text-sm md:text-base lg:text-lg opacity-100'>
             I help other developers land their dream's job 🚀
           </p>
-          <div id="ctaButtons" class='animated flex flex-wrap gap-4 justify-center mt-5'>
+          <div class='animated flex flex-wrap gap-4 justify-center mt-5'>
             <a href='#about' class='py-2 px-4 rounded truncate text-xs md:text-sm lg:text-base bg-black dark:bg-white text-white dark:text-black hover:opacity-75 blend'>
               Mentoring
             </a>
@@ -114,7 +154,14 @@ const stack = [
 
       <!-- About Section -->
       <section id="about" class="animate">
-        <article>
+        <article id="about-developer" data-focus="developer">
+          <p>I am a <b>Software Developer</b> with background as a <b>Mechanical Engineer</b> and an <b>amateur drummer</b>.</p>
+          <p>I'm passionate about software development and the power it gives me to bring ideas to life — whether they're my own or someone else's — creating user-focused products that truly matter.</p>
+          <p>I'm detail-oriented in both the visual aspects of development and the code itself. I care deeply about writing clean, organized, and readable code, following logical design patterns that fit the product I'm building.</p>
+          <p>Now</p>
+          <p>I work at Promofarma by DocMorris as a Mobile Developer, focusing on the versions of the app deployed in Germany and the Netherlands. My team owns the NFC-based scanning of public health insurance cards, giving users direct access to their electronic prescriptions in the app.</p>
+        </article>
+        <article id="about-mentor" data-focus="mentor" hidden>
           <p>I am a <b>Software Developer</b> with background as a <b>Mechanical Engineer</b>.</p>
           <p>Throughout my career, I've worked in various roles—both as a Software Developer and as a Mechanical Engineer. To get there, I've been through dozens of interviews: in English and Spanish; in Argentina, Spain, and remotely; with HR teams, hiring managers, and tech leads.</p>
           <p>I know how tough it is to land your first professional job, go through your first interviews, and tackle your first technical assessments. I've felt the frustration of waiting for a call or email about a job you were excited about, only to hear nothing back.</p>


### PR DESCRIPTION
## Summary
- Restore the original "developer" hero/About content alongside the current "mentor" content, both shipped in the static build.
- Add a Netlify Function (`focus-flag`) backed by Netlify Blobs so which variant is shown can be toggled without a redeploy (defaults to `developer`).
- Document the toggle command in the README.

## Test plan
- [x] `npm run build` (astro check + build) passes with no errors
- [x] Verified locally with `netlify dev`: default flag renders developer content
- [x] Verified locally with `netlify dev`: forcing the flag to `mentor` swaps hero + About content client-side

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>